### PR TITLE
Add missing informations when an error is thrown

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject curbside/abracad "0.4.19"
+(defproject curbside/abracad "0.4.20-SNAPSHOT"
   :description "De/serialize Clojure data structures with Avro."
   :url "http://github.com/damballa/abracad"
   :licenses [{:name "Eclipse Public License"


### PR DESCRIPTION
When an error in avro is thrown, we want to know which fields have a problem.

it was painful to integrate big schema with non-null fields without that